### PR TITLE
Track metadata write-path (#28 partial)

### DIFF
--- a/docs/audio-format-strategy.md
+++ b/docs/audio-format-strategy.md
@@ -1,0 +1,58 @@
+# Audio Format Strategy
+
+## Target formats
+
+The library normalizes all audio to three formats:
+
+| Format | Extension | Type | Metadata |
+|---|---|---|---|
+| AIFF | `.aif` | Lossless (uncompressed PCM) | ID3v2 |
+| MP3 | `.mp3` | Lossy | ID3v2 |
+| AAC | `.m4a` | Lossy | MP4 atoms |
+
+### Why these three?
+
+- **AIFF** — Lossless with full hardware compatibility (all CDJs from 2009+). FLAC is smaller but not supported by CDJ-2000NXS which is still common in clubs. AIFF has ID3v2 metadata support, unlike WAV.
+- **MP3** — Kept as-is for legacy files. Converting lossy→lossy degrades quality for no gain.
+- **M4A/AAC** — Kept as-is for existing AAC files. Used as the transcode target for other lossy formats since AAC is a better codec than MP3 at the same bitrate.
+
+## Import conversion rules
+
+| Source format | Action | Reason |
+|---|---|---|
+| WAV | → `.aif` | Same PCM, better metadata |
+| FLAC | → `.aif` | Decode lossless, gains hardware compat |
+| ALAC (`.m4a`) | → `.aif` | Lossless→lossless |
+| WavPack (`.wv`) | → `.aif` | Lossless→lossless |
+| APE (`.ape`) | → `.aif` | Lossless→lossless |
+| AIFF | keep | Already target format |
+| MP3 | keep | Avoid lossy→lossy |
+| M4A (AAC) | keep | Avoid lossy→lossy |
+| `.aac` (raw) | → `.m4a` | Wrap in MP4 container for metadata support |
+| OGG Vorbis | → `.m4a` | AAC is better codec at same bitrate |
+| Opus | → `.m4a` | Same reasoning |
+| WMA | → `.m4a` | Legacy Windows format |
+
+### ALAC detection
+
+ALAC and AAC both use `.m4a` extension. The import pipeline must detect the codec to decide whether to convert to AIFF (lossless) or keep as-is (lossy AAC).
+
+## Metadata strategy
+
+All three target formats support rich metadata via lofty:
+
+- **AIFF / MP3** — ID3v2 tags. Custom fields via TXXX frames (ISRC, AcoustID, MusicBrainz Recording ID).
+- **M4A** — MP4 atoms. Custom fields via `----:com.apple.iTunes:*` atoms.
+
+Metadata is always written to both:
+1. The audio file tags
+2. The Rekordbox database
+
+## Hardware compatibility reference
+
+See [DJ hardware format support](../docs/dj-hardware-formats.md) or the CLAUDE.md for per-model details.
+
+Summary:
+- **WAV + AIFF + MP3 + AAC** — all CDJs from 2009 onward
+- **FLAC** — CDJ-2000NXS2+, CDJ-3000, all Denon Engine OS players, but NOT CDJ-2000NXS
+- **ALAC** — CDJ-2000NXS2+, CDJ-3000, Denon, but limited XDJ support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod matcher;
 pub mod rekordbox;
 pub mod services;
 pub mod spotify;
+pub mod tags;

--- a/src/rekordbox.rs
+++ b/src/rekordbox.rs
@@ -152,6 +152,28 @@ impl Library {
         Ok(Library { db })
     }
 
+    pub fn track_by_id(&self, content_id: i64) -> Result<Option<Track>> {
+        self.db.with_conn(move |conn| {
+            let id_str = content_id.to_string();
+            let mut stmt = conn.prepare(
+                "SELECT c.ID, c.Title,
+                        a.Name, al.Name, g.Name, k.ScaleName,
+                        c.BPM, c.Length, c.Rating, c.DJPlayCount,
+                        c.FolderPath, c.TrackNo,
+                        l.Name, c.ColorID, c.ImagePath
+                 FROM djmdContent c
+                 LEFT JOIN djmdArtist  a  ON c.ArtistID  = a.ID
+                 LEFT JOIN djmdAlbum   al ON c.AlbumID   = al.ID
+                 LEFT JOIN djmdGenre   g  ON c.GenreID   = g.ID
+                 LEFT JOIN djmdKey     k  ON c.KeyID     = k.ID
+                 LEFT JOIN djmdLabel   l  ON c.LabelID   = l.ID
+                 WHERE c.ID = ?1",
+            )?;
+            let track = stmt.query_row([&id_str], map_track_row).ok();
+            Ok(track)
+        })
+    }
+
     pub fn tracks(&self) -> Result<Vec<Track>> {
         self.db.with_conn(|conn| {
             let mut stmt = conn.prepare(
@@ -622,6 +644,27 @@ impl Track {
     }
 }
 
+/// Fields that can be updated on a track. `None` = don't change.
+#[derive(Debug, Clone, Default)]
+pub struct TrackUpdate {
+    pub title: Option<String>,
+    pub artist: Option<Option<String>>,
+    pub album: Option<Option<String>>,
+    pub genre: Option<Option<String>>,
+    pub label: Option<Option<String>>,
+    pub key: Option<Option<String>>,
+    pub remixer: Option<Option<String>>,
+    pub year: Option<Option<i32>>,
+    /// BPM as displayed (e.g. 128.0), stored ×100 in DB
+    pub bpm: Option<Option<f32>>,
+    pub rating: Option<Option<i32>>,
+    pub color_id: Option<Option<String>>,
+    // Enrichment fields (not in Rekordbox DB, only in file tags)
+    pub isrc: Option<Option<String>>,
+    pub acoustid_id: Option<Option<String>>,
+    pub musicbrainz_recording_id: Option<Option<String>>,
+}
+
 fn build_filter_conditions(f: &TrackFilter) -> Vec<String> {
     let mut conditions = vec!["c.rb_local_deleted = 0".to_string()];
     if let Some(min) = f.bpm_min {
@@ -698,6 +741,92 @@ impl Library {
         Ok((color, overview))
     }
 
+    /// Update track metadata in the Rekordbox DB. Handles upsert into
+    /// lookup tables (djmdArtist, djmdAlbum, etc.) and updates djmdContent.
+    pub fn update_track(&self, content_id: i64, update: &TrackUpdate) -> Result<()> {
+        self.db.with_conn(move |conn| {
+            let id_str = content_id.to_string();
+            let mut sets: Vec<String> = Vec::new();
+            let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+            if let Some(ref title) = update.title {
+                sets.push("Title = ?".into());
+                params.push(Box::new(title.clone()));
+            }
+
+            if let Some(ref artist) = update.artist {
+                let fk = upsert_lookup(conn, "djmdArtist", artist.as_deref())?;
+                sets.push("ArtistID = ?".into());
+                params.push(Box::new(fk));
+            }
+
+            if let Some(ref album) = update.album {
+                let fk = upsert_lookup(conn, "djmdAlbum", album.as_deref())?;
+                sets.push("AlbumID = ?".into());
+                params.push(Box::new(fk));
+            }
+
+            if let Some(ref genre) = update.genre {
+                let fk = upsert_lookup(conn, "djmdGenre", genre.as_deref())?;
+                sets.push("GenreID = ?".into());
+                params.push(Box::new(fk));
+            }
+
+            if let Some(ref label) = update.label {
+                let fk = upsert_lookup(conn, "djmdLabel", label.as_deref())?;
+                sets.push("LabelID = ?".into());
+                params.push(Box::new(fk));
+            }
+
+            if let Some(ref key) = update.key {
+                let fk = upsert_key(conn, key.as_deref())?;
+                sets.push("KeyID = ?".into());
+                params.push(Box::new(fk));
+            }
+
+            if let Some(ref remixer) = update.remixer {
+                sets.push("Remixer = ?".into());
+                params.push(Box::new(remixer.clone()));
+            }
+
+            if let Some(ref year) = update.year {
+                sets.push("ReleaseYear = ?".into());
+                params.push(Box::new(*year));
+            }
+
+            if let Some(ref bpm) = update.bpm {
+                let db_bpm = bpm.map(|b| (b * 100.0) as i32);
+                sets.push("BPM = ?".into());
+                params.push(Box::new(db_bpm));
+            }
+
+            if let Some(ref rating) = update.rating {
+                sets.push("Rating = ?".into());
+                params.push(Box::new(*rating));
+            }
+
+            if let Some(ref color_id) = update.color_id {
+                sets.push("ColorID = ?".into());
+                params.push(Box::new(color_id.clone()));
+            }
+
+            if sets.is_empty() {
+                return Ok(());
+            }
+
+            let sql = format!(
+                "UPDATE djmdContent SET {} WHERE ID = ?",
+                sets.join(", ")
+            );
+            params.push(Box::new(id_str));
+
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|p| p.as_ref()).collect();
+            conn.execute(&sql, param_refs.as_slice())?;
+            Ok(())
+        })
+    }
+
     pub fn load_cues(&self, content_id: i64) -> Result<Vec<CuePoint>> {
         self.db.with_conn(move |conn| {
             let id_str = content_id.to_string();
@@ -722,5 +851,67 @@ impl Library {
             Ok(cues)
         })
     }
+}
+
+/// Find or create a row in a simple lookup table (djmdArtist, djmdAlbum, etc.)
+/// that has `ID` (VARCHAR) and `Name` columns. Returns the ID as Option<String>.
+/// If `name` is None, returns None (clears the FK).
+fn upsert_lookup(conn: &rusqlite::Connection, table: &str, name: Option<&str>) -> Result<Option<String>> {
+    let name = match name {
+        Some(n) if !n.is_empty() => n,
+        _ => return Ok(None),
+    };
+
+    // Try to find existing
+    let sql = format!("SELECT ID FROM {} WHERE Name = ?1", table);
+    let existing: Option<String> = conn
+        .query_row(&sql, [name], |row| row.get(0))
+        .ok();
+
+    if let Some(id) = existing {
+        return Ok(Some(id));
+    }
+
+    // Insert new — generate a numeric ID from max existing + 1
+    let max_sql = format!("SELECT MAX(CAST(ID AS INTEGER)) FROM {}", table);
+    let max_id: i64 = conn
+        .query_row(&max_sql, [], |row| row.get::<_, Option<i64>>(0))
+        .unwrap_or(None)
+        .unwrap_or(0);
+    let new_id = (max_id + 1).to_string();
+
+    let insert_sql = format!("INSERT INTO {} (ID, Name) VALUES (?1, ?2)", table);
+    conn.execute(&insert_sql, params![&new_id, name])?;
+
+    Ok(Some(new_id))
+}
+
+/// Find or create a key in djmdKey. Uses `ScaleName` column.
+fn upsert_key(conn: &rusqlite::Connection, scale_name: Option<&str>) -> Result<Option<String>> {
+    let name = match scale_name {
+        Some(n) if !n.is_empty() => n,
+        _ => return Ok(None),
+    };
+
+    let existing: Option<String> = conn
+        .query_row("SELECT ID FROM djmdKey WHERE ScaleName = ?1", [name], |row| row.get(0))
+        .ok();
+
+    if let Some(id) = existing {
+        return Ok(Some(id));
+    }
+
+    let max_id: i64 = conn
+        .query_row("SELECT MAX(CAST(ID AS INTEGER)) FROM djmdKey", [], |row| row.get::<_, Option<i64>>(0))
+        .unwrap_or(None)
+        .unwrap_or(0);
+    let new_id = (max_id + 1).to_string();
+
+    conn.execute(
+        "INSERT INTO djmdKey (ID, ScaleName) VALUES (?1, ?2)",
+        params![&new_id, name],
+    )?;
+
+    Ok(Some(new_id))
 }
 

--- a/src/services/track.rs
+++ b/src/services/track.rs
@@ -1,5 +1,8 @@
-use crate::rekordbox::{Library, Track};
+use std::path::Path;
+use crate::config::Config;
+use crate::rekordbox::{Library, Track, TrackUpdate};
 use crate::spotify::SpotifyTrack;
+use crate::tags::TagUpdate;
 
 // ── Query types ─────────────────────────────────────────────────────────────
 
@@ -27,6 +30,48 @@ pub struct GigMatchEntry {
 }
 
 // ── Service functions ───────────────────────────────────────────────────────
+
+/// Save track metadata to both the Rekordbox DB and the audio file tags.
+/// Returns an error message if either write fails (but attempts both).
+pub fn save_track_metadata(
+    lib: &Library,
+    track_id: i64,
+    update: &TrackUpdate,
+    config: &Config,
+) -> Result<(), String> {
+    // Write to Rekordbox DB
+    lib.update_track(track_id, update)
+        .map_err(|e| format!("DB update failed: {e}"))?;
+
+    // Write to file tags if we can resolve the path
+    if let Some(track) = lib.track_by_id(track_id).ok().flatten() {
+        if let Some(ref fp) = track.file_path {
+            let resolved = config.apply_mappings(fp);
+            let path = Path::new(&resolved);
+            if path.exists() {
+                let tag_update = TagUpdate {
+                    title: update.title.clone(),
+                    artist: update.artist.clone().flatten(),
+                    album: update.album.clone().flatten(),
+                    genre: update.genre.clone().flatten(),
+                    label: update.label.clone().flatten(),
+                    key: update.key.clone().flatten(),
+                    remixer: update.remixer.clone().flatten(),
+                    year: update.year.flatten(),
+                    bpm: update.bpm.flatten(),
+                    isrc: update.isrc.clone().flatten(),
+                    acoustid_id: update.acoustid_id.clone().flatten(),
+                    musicbrainz_recording_id: update.musicbrainz_recording_id.clone().flatten(),
+                };
+                if let Err(e) = crate::tags::write_tags(path, &tag_update) {
+                    return Err(format!("Tag write failed: {e}"));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
 
 pub fn query_tracks(lib: &Library, query: TrackQuery) -> Vec<Track> {
     match query {

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -27,6 +27,81 @@ fn write_item(tag: &mut lofty::tag::Tag, key: ItemKey, value: &str) {
     tag.push(TagItem::new(key, ItemValue::Text(value.to_string())));
 }
 
+/// Fields that can be written to audio file tags.
+#[derive(Debug, Clone, Default)]
+pub struct TagUpdate {
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub genre: Option<String>,
+    pub label: Option<String>,
+    pub key: Option<String>,
+    pub remixer: Option<String>,
+    pub year: Option<i32>,
+    pub bpm: Option<f32>,
+    pub isrc: Option<String>,
+    pub acoustid_id: Option<String>,
+    pub musicbrainz_recording_id: Option<String>,
+}
+
+/// Write metadata tags to an audio file. Only fields that are `Some` are written;
+/// existing tags for `None` fields are left untouched.
+pub fn write_tags(path: &Path, update: &TagUpdate) -> Result<(), String> {
+    let mut file = Probe::open(path)
+        .map_err(|e| format!("lofty open: {e}"))?
+        .read()
+        .map_err(|e| format!("lofty read: {e}"))?;
+
+    let tag = file.primary_tag_mut()
+        .ok_or_else(|| "file has no primary tag".to_string())?;
+
+    if let Some(ref v) = update.title {
+        tag.set_title(v.clone());
+    }
+    if let Some(ref v) = update.artist {
+        tag.set_artist(v.clone());
+    }
+    if let Some(ref v) = update.album {
+        tag.set_album(v.clone());
+    }
+    if let Some(ref v) = update.genre {
+        tag.set_genre(v.clone());
+    }
+    if let Some(ref v) = update.label {
+        write_item(tag, ItemKey::Label, v);
+    }
+    if let Some(ref v) = update.key {
+        write_item(tag, ItemKey::InitialKey, v);
+    }
+    if let Some(ref v) = update.remixer {
+        write_item(tag, ItemKey::Remixer, v);
+    }
+    if let Some(year) = update.year {
+        write_item(tag, ItemKey::Year, &year.to_string());
+    }
+    if let Some(bpm) = update.bpm {
+        write_item(tag, ItemKey::Bpm, &format!("{:.0}", bpm));
+    }
+    if let Some(ref v) = update.isrc {
+        write_item(tag, ItemKey::Isrc, v);
+    }
+    if let Some(ref v) = update.acoustid_id {
+        write_item(tag, ItemKey::Unknown("Acoustid Id".to_string()), v);
+    }
+    if let Some(ref v) = update.musicbrainz_recording_id {
+        write_item(tag, ItemKey::Unknown("MusicBrainz Recording Id".to_string()), v);
+    }
+
+    let mut f = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|e| format!("open for write: {e}"))?;
+
+    file.save_to(&mut f, lofty::config::WriteOptions::default())
+        .map_err(|e| format!("lofty save: {e}"))
+}
+
 /// Migrate ISRC, AcoustID, and MusicBrainz Recording ID from `src` to `dst`.
 pub fn migrate_tags(src: &Path, dst: &Path) -> Result<(), String> {
     let src_file = Probe::open(src)


### PR DESCRIPTION
## Summary
- `TrackUpdate` struct with all editable fields (title, artist, album, genre, label, key, remixer, year, bpm, rating, color_id, isrc, acoustid_id, musicbrainz_recording_id)
- `Library::update_track()` with upsert into Rekordbox lookup tables (djmdArtist, djmdAlbum, etc.)
- `Library::track_by_id()` for single-track lookup
- `TagUpdate` + `write_tags()` for writing to AIFF/MP3/M4A via lofty
- `services::track::save_track_metadata()` orchestrates DB + file tag sync
- Audio format strategy documentation

Partial work on #28 — write-path is complete, UI editing deferred.

## Test plan
- [ ] Unit test for `update_track` with lookup table upsert
- [ ] Integration test for `write_tags` on AIFF/MP3/M4A files
- [x] Compiles cleanly